### PR TITLE
Fix remaining %>% pipe from README to use base |>

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -52,7 +52,7 @@ library(purrr)
 mtcars |> 
   split(mtcars$cyl) |>  # from base R
   map(\(df) lm(mpg ~ wt, data = df)) |> 
-  map(summary) %>%
+  map(summary) |>
   map_dbl("r.squared")
 ```
 


### PR DESCRIPTION
Change remaining `%>%` pipe to use base `|>` like the rest of the chunk (looks like it was missed in [this update](https://github.com/tidyverse/purrr/commit/c22dd639b7d18f29b495203212f10223fbb9d893)).

Apologies if this is too minor to be useful to have forked for. It seemed like a quick enough fix for opening an issue to be silly but if I misunderstood the relevant norms I'm sorry.